### PR TITLE
Add /new command to record expenses

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,4 +1,5 @@
-import os, json, logging
+import os, json, logging, re, shlex
+from datetime import datetime
 from typing import List
 import requests
 from telegram import Update
@@ -42,11 +43,84 @@ async def cmd_authorized(update: Update, _: ContextTypes.DEFAULT_TYPE):
     uid = update.effective_user.id if update.effective_user else 0
     await update.message.reply_text("true" if is_allowed(uid) else "false")
 
+async def cmd_new(update: Update, _: ContextTypes.DEFAULT_TYPE):
+    if not await ensure_access(update):
+        return
+
+    msg = update.message
+    if not msg or not msg.text:
+        return
+
+    try:
+        parts = shlex.split(msg.text)
+    except ValueError:
+        await msg.reply_text("Ambiguous command. Please check your quotes.")
+        return
+
+    if parts and parts[0].startswith("/new"):
+        parts = parts[1:]
+
+    if not parts:
+        await msg.reply_text("Ambiguous command. Not enough parameters.")
+        return
+
+    idx = 0
+    date_str = ""
+    msg_dt = msg.date
+    date_token = parts[0]
+    date_match = re.fullmatch(r"(\d{1,2})/(\d{1,2})(?:/(\d{4}))?", date_token)
+    if date_match:
+        day = int(date_match.group(1))
+        month = int(date_match.group(2))
+        year = int(date_match.group(3)) if date_match.group(3) else msg_dt.year
+        try:
+            date_obj = datetime(year, month, day)
+            date_str = date_obj.date().isoformat()
+            idx = 1
+        except ValueError:
+            await msg.reply_text("Ambiguous command. Invalid date.")
+            return
+    else:
+        date_str = msg_dt.date().isoformat()
+
+    if len(parts) - idx < 2:
+        await msg.reply_text("Ambiguous command. Not enough parameters.")
+        return
+
+    amount_str = parts[idx]
+    idx += 1
+
+    remaining = parts[idx:]
+    if len(remaining) > 3:
+        await msg.reply_text("Ambiguous command. Please quote description if it contains spaces.")
+        return
+
+    description = remaining[0]
+    category = remaining[1] if len(remaining) >= 2 else ""
+    type_ = remaining[2] if len(remaining) >= 3 else ""
+
+    try:
+        amount = float(amount_str)
+    except ValueError:
+        await msg.reply_text("Ambiguous command. Amount must be a number.")
+        return
+
+    entry = {
+        "date": date_str,
+        "amount": amount,
+        "description": description,
+        "category": category,
+        "type": type_,
+    }
+
+    await msg.reply_text(json.dumps(entry))
+
 def main():
     app = ApplicationBuilder().token(BOT_TOKEN).build()
     app.add_handler(CommandHandler("start", cmd_start))
     app.add_handler(CommandHandler("whoami", cmd_whoami))
     app.add_handler(CommandHandler("authorized", cmd_authorized))
+    app.add_handler(CommandHandler("new", cmd_new))
     app.run_polling(allowed_updates=["message"])
 
 if __name__ == "__main__":

--- a/tests/test_cmd_new.py
+++ b/tests/test_cmd_new.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import json
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+# allow importing the bot module
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# ensure BOT_TOKEN env var for module import
+os.environ.setdefault("BOT_TOKEN", "TEST_TOKEN")
+
+from bot.bot import cmd_new
+
+class DummyChat:
+    def __init__(self, message):
+        self.message = message
+        self.sent = []
+
+    async def send_message(self, text):
+        self.sent.append(text)
+
+class DummyMessage:
+    def __init__(self, text, date):
+        self.text = text
+        self.date = date
+        self.replies = []
+
+    async def reply_text(self, text):
+        self.replies.append(text)
+
+class DummyUser:
+    def __init__(self, uid=123):
+        self.id = uid
+
+class DummyUpdate:
+    def __init__(self, text, date):
+        self.message = DummyMessage(text, date)
+        self.effective_user = DummyUser()
+        self.effective_chat = DummyChat(self.message)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_cmd_new_without_date():
+    dt = datetime(2024, 1, 2)
+    upd = DummyUpdate("/new 10 coffee", dt)
+    run(cmd_new(upd, None))
+    assert len(upd.message.replies) == 1
+    data = json.loads(upd.message.replies[0])
+    assert data == {
+        "date": dt.date().isoformat(),
+        "amount": 10.0,
+        "description": "coffee",
+        "category": "",
+        "type": "",
+    }
+
+
+def test_cmd_new_with_date_and_year_default():
+    msg_date = datetime(2024, 5, 4)
+    upd = DummyUpdate("/new 01/02 5 lunch food", msg_date)
+    run(cmd_new(upd, None))
+    data = json.loads(upd.message.replies[0])
+    assert data == {
+        "date": "2024-02-01",
+        "amount": 5.0,
+        "description": "lunch",
+        "category": "food",
+        "type": "",
+    }
+
+
+def test_cmd_new_invalid_date():
+    msg_date = datetime(2024, 1, 1)
+    upd = DummyUpdate("/new 31/02 5 lunch", msg_date)
+    run(cmd_new(upd, None))
+    assert upd.message.replies == ["Ambiguous command. Invalid date."]
+
+
+def test_cmd_new_missing_parameters():
+    msg_date = datetime(2024, 1, 1)
+    upd = DummyUpdate("/new 10", msg_date)
+    run(cmd_new(upd, None))
+    assert upd.message.replies == ["Ambiguous command. Not enough parameters."]
+
+
+def test_cmd_new_unquoted_description_warning():
+    msg_date = datetime(2024, 1, 1)
+    upd = DummyUpdate("/new 5 too many words here", msg_date)
+    run(cmd_new(upd, None))
+    assert upd.message.replies == ["Ambiguous command. Please quote description if it contains spaces."]


### PR DESCRIPTION
## Summary
- add `/new` command that parses expense parameters and echoes entry as JSON
- require day and month when specifying a date, defaulting to the message date otherwise
- add tests covering `/new` command behavior and error handling

## Testing
- `python -m py_compile bot/bot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb79fa8ce4832aa953916364de0689